### PR TITLE
Build creation/edit/delete CRUD for freelancers (ServiceListing)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "cs520-VTDK",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -2,7 +2,7 @@
 # https://supabase.com/docs/guides/local-development/cli/config
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
-project_id = "supabase"
+project_id = "pfnybvxlmqmiyifhyzqw"
 
 [api]
 enabled = true
@@ -394,6 +394,18 @@ s3_secret_key = "env(S3_SECRET_KEY)"
 # declarative_schema_path = "./declarative"
 # JSON string passed through to pg-delta SQL formatting.
 # format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"
+
+[functions.manage-listing]
+enabled = true
+verify_jwt = false
+import_map = "./functions/manage-listing/deno.json"
+entrypoint = "./functions/manage-listing/index.ts"
+
+[functions.get-listings]
+enabled = true
+verify_jwt = false
+import_map = "./functions/get-listings/deno.json"
+entrypoint = "./functions/get-listings/index.ts"
 
 [functions.generate-pricing-report]
 enabled = true

--- a/supabase/functions/_shared/supabase.ts
+++ b/supabase/functions/_shared/supabase.ts
@@ -1,0 +1,29 @@
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+/**
+ * Creates a Supabase client authenticated as the requesting user.
+ * The user's JWT is extracted from the Authorization header so that
+ * Row Level Security policies apply to every query.
+ */
+export function createUserClient(req: Request) {
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) {
+    throw new Error("Missing Authorization header");
+  }
+
+  return createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_ANON_KEY")!,
+    {
+      global: { headers: { Authorization: authHeader } },
+    },
+  );
+}
+
+/** Standard CORS headers for browser requests. */
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+};

--- a/supabase/functions/get-listings/deno.json
+++ b/supabase/functions/get-listings/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "@supabase/functions-js": "jsr:@supabase/functions-js@^2",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/get-listings/index.ts
+++ b/supabase/functions/get-listings/index.ts
@@ -1,0 +1,83 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+import { createUserClient, corsHeaders } from "../_shared/supabase.ts";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function errorResponse(message: string, status = 400) {
+  return jsonResponse({ error: message }, status);
+}
+
+Deno.serve(async (req) => {
+  // Handle CORS preflight
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "GET") {
+    return errorResponse("Method not allowed", 405);
+  }
+
+  try {
+    const supabase = createUserClient(req);
+    const url = new URL(req.url);
+    const id = url.searchParams.get("id");
+    const freelancerId = url.searchParams.get("freelancer_id");
+    const categoryId = url.searchParams.get("category_id");
+    const includeInactive = url.searchParams.get("include_inactive") === "true";
+
+    // Join pricing models, category name, and freelancer info
+    const selectQuery = `
+      *,
+      pricing_models (*),
+      categories (name, slug),
+      users!listings_freelancer_id_fkey (business_name, avatar_url, summary)
+    `;
+
+    // Single listing by ID
+    if (id) {
+      const { data, error } = await supabase
+        .from("listings")
+        .select(selectQuery)
+        .eq("id", id)
+        .single();
+
+      if (error) {
+        return errorResponse(error.message, 404);
+      }
+      return jsonResponse(data);
+    }
+
+    // Build filtered query
+    let query = supabase.from("listings").select(selectQuery);
+
+    if (freelancerId) {
+      query = query.eq("freelancer_id", freelancerId);
+    }
+
+    if (categoryId) {
+      query = query.eq("category_id", categoryId);
+    }
+
+    // By default only return active listings (unless requesting own or explicitly asking for inactive)
+    if (!includeInactive) {
+      query = query.eq("is_active", true);
+    }
+
+    query = query.order("created_at", { ascending: false });
+
+    const { data, error } = await query;
+
+    if (error) {
+      return errorResponse(error.message, 400);
+    }
+
+    return jsonResponse(data);
+  } catch (err) {
+    return errorResponse(err.message, 500);
+  }
+});

--- a/supabase/functions/manage-listing/deno.json
+++ b/supabase/functions/manage-listing/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "@supabase/functions-js": "jsr:@supabase/functions-js@^2",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/manage-listing/index.ts
+++ b/supabase/functions/manage-listing/index.ts
@@ -1,0 +1,232 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+import { createUserClient, corsHeaders } from "../_shared/supabase.ts";
+
+// ── Types ────────────────────────────────────────────────────
+
+interface PricingModelInput {
+  strategy_type: "fixed" | "hourly" | "project";
+  base_price: number;
+  unit?: string | null;
+}
+
+interface CreateListingBody {
+  category_id: string;
+  title: string;
+  description: string;
+  pricing_models?: PricingModelInput[];
+}
+
+interface UpdateListingBody {
+  id: string;
+  title?: string;
+  description?: string;
+  is_active?: boolean;
+  pricing_models?: PricingModelInput[];
+}
+
+interface DeleteListingBody {
+  id: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function errorResponse(message: string, status = 400) {
+  return jsonResponse({ error: message }, status);
+}
+
+// ── Handlers ─────────────────────────────────────────────────
+
+async function handleCreate(req: Request) {
+  const supabase = createUserClient(req);
+  const body: CreateListingBody = await req.json();
+
+  // Validate required fields
+  if (!body.category_id || !body.title || !body.description) {
+    return errorResponse("category_id, title, and description are required.");
+  }
+
+  // Get the authenticated user's ID
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return errorResponse("Unauthorized", 401);
+  }
+
+  // Insert the listing (RLS ensures freelancer_id = auth.uid())
+  const { data: listing, error: listingError } = await supabase
+    .from("listings")
+    .insert({
+      freelancer_id: user.id,
+      category_id: body.category_id,
+      title: body.title,
+      description: body.description,
+    })
+    .select()
+    .single();
+
+  if (listingError) {
+    return errorResponse(listingError.message, 403);
+  }
+
+  // Insert pricing models if provided
+  let pricingModels = null;
+  if (body.pricing_models && body.pricing_models.length > 0) {
+    const rows = body.pricing_models.map((pm) => ({
+      listing_id: listing.id,
+      strategy_type: pm.strategy_type,
+      base_price: pm.base_price,
+      unit: pm.unit ?? null,
+    }));
+
+    const { data, error: pmError } = await supabase
+      .from("pricing_models")
+      .insert(rows)
+      .select();
+
+    if (pmError) {
+      // Clean up the listing if pricing models fail
+      await supabase.from("listings").delete().eq("id", listing.id);
+      return errorResponse(`Failed to create pricing models: ${pmError.message}`, 400);
+    }
+    pricingModels = data;
+  }
+
+  return jsonResponse({ ...listing, pricing_models: pricingModels ?? [] }, 201);
+}
+
+async function handleUpdate(req: Request) {
+  const supabase = createUserClient(req);
+  const body: UpdateListingBody = await req.json();
+
+  if (!body.id) {
+    return errorResponse("Listing id is required.");
+  }
+
+  // Build the update payload (only include provided fields)
+  const updates: Record<string, unknown> = {};
+  if (body.title !== undefined) updates.title = body.title;
+  if (body.description !== undefined) updates.description = body.description;
+  if (body.is_active !== undefined) updates.is_active = body.is_active;
+
+  // Update the listing if there are fields to update
+  let listing;
+  if (Object.keys(updates).length > 0) {
+    const { data, error } = await supabase
+      .from("listings")
+      .update(updates)
+      .eq("id", body.id)
+      .select()
+      .single();
+
+    if (error) {
+      return errorResponse(error.message, 403);
+    }
+    listing = data;
+  } else {
+    // No listing fields to update, just fetch the current listing
+    const { data, error } = await supabase
+      .from("listings")
+      .select()
+      .eq("id", body.id)
+      .single();
+
+    if (error) {
+      return errorResponse(error.message, 404);
+    }
+    listing = data;
+  }
+
+  // Replace pricing models if provided (delete old, insert new)
+  let pricingModels;
+  if (body.pricing_models !== undefined) {
+    // Delete existing pricing models for this listing
+    await supabase
+      .from("pricing_models")
+      .delete()
+      .eq("listing_id", body.id);
+
+    if (body.pricing_models.length > 0) {
+      const rows = body.pricing_models.map((pm) => ({
+        listing_id: body.id,
+        strategy_type: pm.strategy_type,
+        base_price: pm.base_price,
+        unit: pm.unit ?? null,
+      }));
+
+      const { data, error: pmError } = await supabase
+        .from("pricing_models")
+        .insert(rows)
+        .select();
+
+      if (pmError) {
+        return errorResponse(`Failed to update pricing models: ${pmError.message}`, 400);
+      }
+      pricingModels = data;
+    } else {
+      pricingModels = [];
+    }
+  } else {
+    // Pricing models not touched — fetch current ones
+    const { data } = await supabase
+      .from("pricing_models")
+      .select()
+      .eq("listing_id", body.id);
+    pricingModels = data;
+  }
+
+  return jsonResponse({ ...listing, pricing_models: pricingModels ?? [] });
+}
+
+async function handleDelete(req: Request) {
+  const supabase = createUserClient(req);
+  const body: DeleteListingBody = await req.json();
+
+  if (!body.id) {
+    return errorResponse("Listing id is required.");
+  }
+
+  // Delete the listing (ON DELETE CASCADE removes pricing_models)
+  const { error } = await supabase
+    .from("listings")
+    .delete()
+    .eq("id", body.id);
+
+  if (error) {
+    return errorResponse(error.message, 403);
+  }
+
+  return jsonResponse({ message: "Listing deleted successfully." });
+}
+
+// ── Router ───────────────────────────────────────────────────
+
+Deno.serve(async (req) => {
+  // Handle CORS preflight
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    switch (req.method) {
+      case "POST":
+        return await handleCreate(req);
+      case "PUT":
+        return await handleUpdate(req);
+      case "DELETE":
+        return await handleDelete(req);
+      default:
+        return errorResponse("Method not allowed", 405);
+    }
+  } catch (err) {
+    return errorResponse(err.message, 500);
+  }
+});

--- a/supabase/migrations/20250101000013_fix_rls_role_checks.sql
+++ b/supabase/migrations/20250101000013_fix_rls_role_checks.sql
@@ -1,0 +1,117 @@
+-- ============================================================
+-- Migration 013: Fix RLS role checks
+-- The original migrations checked (auth.jwt() ->> 'role') which
+-- always returns 'authenticated' in Supabase. Custom roles live
+-- in the public.users table, not the JWT.
+-- This migration adds a helper function and replaces all broken
+-- role-based policies across every table.
+-- ============================================================
+
+-- Helper: returns the calling user's role from the users table.
+-- SECURITY DEFINER lets it bypass RLS on the users table itself.
+CREATE OR REPLACE FUNCTION auth_user_role()
+RETURNS text
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+AS $$
+  SELECT role::text FROM public.users WHERE id = auth.uid();
+$$;
+
+-- ── categories ───────────────────────────────────────────────
+DROP POLICY IF EXISTS "categories_all_admin" ON categories;
+CREATE POLICY "categories_all_admin"
+  ON categories FOR ALL
+  TO authenticated
+  USING  (auth_user_role() = 'admin')
+  WITH CHECK (auth_user_role() = 'admin');
+
+-- ── users ────────────────────────────────────────────────────
+DROP POLICY IF EXISTS "users_all_admin" ON users;
+CREATE POLICY "users_all_admin"
+  ON users FOR ALL
+  TO authenticated
+  USING  (auth_user_role() = 'admin')
+  WITH CHECK (auth_user_role() = 'admin');
+
+-- ── listings ─────────────────────────────────────────────────
+DROP POLICY IF EXISTS "listings_insert_freelancer" ON listings;
+CREATE POLICY "listings_insert_freelancer"
+  ON listings FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    auth.uid() = freelancer_id
+    AND auth_user_role() = 'freelancer'
+  );
+
+DROP POLICY IF EXISTS "listings_all_admin" ON listings;
+CREATE POLICY "listings_all_admin"
+  ON listings FOR ALL
+  TO authenticated
+  USING  (auth_user_role() = 'admin')
+  WITH CHECK (auth_user_role() = 'admin');
+
+-- ── pricing_models ───────────────────────────────────────────
+DROP POLICY IF EXISTS "pricing_models_all_admin" ON pricing_models;
+CREATE POLICY "pricing_models_all_admin"
+  ON pricing_models FOR ALL
+  TO authenticated
+  USING  (auth_user_role() = 'admin')
+  WITH CHECK (auth_user_role() = 'admin');
+
+-- ── offers ───────────────────────────────────────────────────
+DROP POLICY IF EXISTS "offers_insert_customer" ON offers;
+CREATE POLICY "offers_insert_customer"
+  ON offers FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    auth.uid() = customer_id
+    AND auth_user_role() = 'customer'
+  );
+
+DROP POLICY IF EXISTS "offers_all_admin" ON offers;
+CREATE POLICY "offers_all_admin"
+  ON offers FOR ALL
+  TO authenticated
+  USING  (auth_user_role() = 'admin')
+  WITH CHECK (auth_user_role() = 'admin');
+
+-- ── transactions ─────────────────────────────────────────────
+DROP POLICY IF EXISTS "transactions_all_admin" ON transactions;
+CREATE POLICY "transactions_all_admin"
+  ON transactions FOR ALL
+  TO authenticated
+  USING  (auth_user_role() = 'admin')
+  WITH CHECK (auth_user_role() = 'admin');
+
+-- ── reviews ──────────────────────────────────────────────────
+DROP POLICY IF EXISTS "reviews_all_admin" ON reviews;
+CREATE POLICY "reviews_all_admin"
+  ON reviews FOR ALL
+  TO authenticated
+  USING  (auth_user_role() = 'admin')
+  WITH CHECK (auth_user_role() = 'admin');
+
+-- ── review_responses ─────────────────────────────────────────
+DROP POLICY IF EXISTS "review_responses_all_admin" ON review_responses;
+CREATE POLICY "review_responses_all_admin"
+  ON review_responses FOR ALL
+  TO authenticated
+  USING  (auth_user_role() = 'admin')
+  WITH CHECK (auth_user_role() = 'admin');
+
+-- ── conversations ────────────────────────────────────────────
+DROP POLICY IF EXISTS "conversations_all_admin" ON conversations;
+CREATE POLICY "conversations_all_admin"
+  ON conversations FOR ALL
+  TO authenticated
+  USING  (auth_user_role() = 'admin')
+  WITH CHECK (auth_user_role() = 'admin');
+
+-- ── messages ─────────────────────────────────────────────────
+DROP POLICY IF EXISTS "messages_all_admin" ON messages;
+CREATE POLICY "messages_all_admin"
+  ON messages FOR ALL
+  TO authenticated
+  USING  (auth_user_role() = 'admin')
+  WITH CHECK (auth_user_role() = 'admin');

--- a/supabase/migrations/20260413190652_remote_commit.sql
+++ b/supabase/migrations/20260413190652_remote_commit.sql
@@ -1,0 +1,65 @@
+drop extension if exists "pg_net";
+
+create extension if not exists "postgis" with schema "public";
+
+create type "public"."geometry_dump" as ("path" integer[], "geom" public.geometry);
+
+create type "public"."valid_detail" as ("valid" boolean, "reason" character varying, "location" public.geometry);
+
+grant delete on table "public"."spatial_ref_sys" to "anon";
+
+grant insert on table "public"."spatial_ref_sys" to "anon";
+
+grant references on table "public"."spatial_ref_sys" to "anon";
+
+grant select on table "public"."spatial_ref_sys" to "anon";
+
+grant trigger on table "public"."spatial_ref_sys" to "anon";
+
+grant truncate on table "public"."spatial_ref_sys" to "anon";
+
+grant update on table "public"."spatial_ref_sys" to "anon";
+
+grant delete on table "public"."spatial_ref_sys" to "authenticated";
+
+grant insert on table "public"."spatial_ref_sys" to "authenticated";
+
+grant references on table "public"."spatial_ref_sys" to "authenticated";
+
+grant select on table "public"."spatial_ref_sys" to "authenticated";
+
+grant trigger on table "public"."spatial_ref_sys" to "authenticated";
+
+grant truncate on table "public"."spatial_ref_sys" to "authenticated";
+
+grant update on table "public"."spatial_ref_sys" to "authenticated";
+
+grant delete on table "public"."spatial_ref_sys" to "postgres";
+
+grant insert on table "public"."spatial_ref_sys" to "postgres";
+
+grant references on table "public"."spatial_ref_sys" to "postgres";
+
+grant select on table "public"."spatial_ref_sys" to "postgres";
+
+grant trigger on table "public"."spatial_ref_sys" to "postgres";
+
+grant truncate on table "public"."spatial_ref_sys" to "postgres";
+
+grant update on table "public"."spatial_ref_sys" to "postgres";
+
+grant delete on table "public"."spatial_ref_sys" to "service_role";
+
+grant insert on table "public"."spatial_ref_sys" to "service_role";
+
+grant references on table "public"."spatial_ref_sys" to "service_role";
+
+grant select on table "public"."spatial_ref_sys" to "service_role";
+
+grant trigger on table "public"."spatial_ref_sys" to "service_role";
+
+grant truncate on table "public"."spatial_ref_sys" to "service_role";
+
+grant update on table "public"."spatial_ref_sys" to "service_role";
+
+


### PR DESCRIPTION
Adds two Supabase Edge Functions that let freelancers create, edit, and delete their service listings. Also fixes a bug in the Row Level Security policies that was silently blocking all role-based access control across every table in the database.

---
### New Files

#### `supabase/functions/_shared/supabase.ts`

A shared helper used by all Edge Functions. Creates an authenticated Supabase client from the caller's JWT so that the database's security rules apply to every query.

---

#### `supabase/functions/manage-listing/` - Write Operations

| Method | What it does |
|--------|--------------|
| `POST` | Create a new listing with one or more pricing models (hourly/fixed/project) |
| `PUT` | Update listing fields and/or replace its pricing models |
| `DELETE` | Delete a listing (automatically removes its pricing models) |

---

#### `supabase/functions/get-listings/` - Read Operations

Fetches listings with their pricing models, category name, and freelancer info joined in. Supports filtering by:

- `?id=`
- `?freelancer_id=`
- `?category_id=`
- `?include_inactive=true`

---

### Bug Fix: RLS Policies Were Broken for All Tables

**Migration:** `supabase/migrations/20250101000013_fix_rls_role_checks.sql`

Every table's role-based policies (freelancer insert, customer insert, admin access) were checking `auth.jwt() ->> 'role'`, which always returns `'authenticated'` in Supabase - not the custom role. Custom roles (`freelancer`, `customer`, `admin`) are stored in the `users` table, not in the JWT.

This migration adds an `auth_user_role()` helper that looks up the role from the `users` table, then recreates all broken policies to use it. No existing policy logic changed, only how the role is read.

---

### Why `--no-verify-jwt`

The functions are deployed with JWT verification disabled at the Edge Runtime gateway level. This is intentional: our project uses ES256 (asymmetric) JWT signing (a newer Supabase default), which has a known incompatibility with the Edge Runtime's built-in `verify_jwt`. Security is not weakened. Row Level Security at the database layer enforces all access control regardless.

That said, maybe someone else could look into this and see how to make it work in dev. I couldn't and it kept returning 401 error for invalid jwt even though it should be valid.