### PR TITLE
chore: audit env variables and map VITE_ML_SERVICE_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,7 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 # Desktop resolves this to the host on both Mac and Windows:
 #   ML_SERVICE_URL=http://host.docker.internal:8000
 #
-# Used by: supabase Edge Function generate-pricing-report
+# Used by: supabase Edge Function generate-pricing-report, frontend (as VITE_ML_SERVICE_URL)
 ML_SERVICE_URL=http://host.docker.internal:8000
 
 # Port the ML service binds to. Railway injects this automatically in

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig(({mode}) => {
       // Remap canonical names from root .env to the VITE_ names the app expects.
       'import.meta.env.VITE_SUPABASE_URL': JSON.stringify(env.SUPABASE_URL),
       'import.meta.env.VITE_SUPABASE_ANON_KEY': JSON.stringify(env.SUPABASE_ANON_KEY),
+      'import.meta.env.VITE_ML_SERVICE_URL': JSON.stringify(env.ML_SERVICE_URL),
     },
     resolve: {
       alias: {

--- a/ml-service/app/models/service_categorizer.py
+++ b/ml-service/app/models/service_categorizer.py
@@ -5,6 +5,8 @@ Uses a Hugging Face sentence-transformer to embed the service description
 and the category name, then computes cosine similarity. A threshold of
 0.35 is used to determine a match (tunable).
 """
+from __future__ import annotations
+
 from fastapi import APIRouter
 from sentence_transformers import SentenceTransformer, util
 


### PR DESCRIPTION
- Confirmed GEMINI_API_KEY leak and redundant .env.example files were already resolved in a prior commit.

- Added missing VITE_ML_SERVICE_URL mapping in vite.config.ts to fix undefined variable in frontend CoreServices.

- Updated central .env.example to document frontend usage of ML_SERVICE_URL.

- Added missing future annotations import to service_categorizer.py.

Closes #72