### PR TITLE
feat(#46): transaction history page + mark complete flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { AuthPage } from './pages/Auth';
 import { FreelancerProfile } from './pages/FreelancerProfile';
 import { UserProfile } from './pages/UserProfile';
 import { FreelancerDashboard } from './pages/FreelancerDashboard';
+import { TransactionsPage } from './pages/TransactionsPage';
 import { supabase } from './lib/supabaseClient';
 import { useInactivityLogout } from './hooks/useInactivityLogout';
 import { Spinner } from './components/Spinner';
@@ -114,12 +115,26 @@ export default function App() {
                   onLogout={handleLogout}
                   onGoToDashboard={() => navigate('/dashboard')}
                   onRoleChange={handleRoleChange}
+                  onViewTransactions={() => navigate('/transactions')}
                 />
               )
               : <Navigate to="/auth" />
           }
         />
         <Route path="*" element={<Navigate to="/" />} />
+        <Route
+          path="/transactions"
+          element={
+            authLoading ? <Spinner /> : user
+              ? (
+                <TransactionsPage
+                  user={user}
+                  onBack={() => navigate('/profile')}
+                />
+              )
+              : <Navigate to="/auth" />
+          }
+        />
       </Routes>
 
       <Footer />

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -22,17 +22,25 @@ export const Navbar = ({ user }: NavbarProps) => {
         <a href="#" className="hover:text-vibrant-coral transition-colors">Pricing</a>
       </div>
       {user ? (
-        <div
-          onClick={() => navigate(user.role === 'freelancer' ? '/dashboard' : '/profile')}
-          className="flex items-center gap-3 cursor-pointer group"
-        >
-          <div className="text-right hidden sm:block">
-            <div className="font-display uppercase text-sm font-bold group-hover:text-vibrant-coral transition-colors leading-none">{user.name}</div>
-            <div className="text-[10px] font-mono uppercase opacity-60 mt-1.5">{user.role}</div>
-          </div>
-          <div className="w-10 h-10 bg-shadow-grey text-white font-display text-xl uppercase border-2 border-black shadow-brutal-sm group-hover:translate-x-1 group-hover:translate-y-1 group-hover:shadow-none transition-all flex items-center justify-center relative">
-            {user.name.charAt(0)}
-            <div className="absolute -top-1 -right-1 w-3 h-3 bg-vibrant-coral border-2 border-black rounded-sm" />
+        <div className="flex items-center gap-4">
+          <Link
+            to="/transactions"
+            className="hidden sm:block font-display uppercase text-sm tracking-widest hover:text-vibrant-coral transition-colors"
+          >
+            Transactions
+          </Link>
+          <div
+            onClick={() => navigate(user.role === 'freelancer' ? '/dashboard' : '/profile')}
+            className="flex items-center gap-3 cursor-pointer group"
+          >
+            <div className="text-right hidden sm:block">
+              <div className="font-display uppercase text-sm font-bold group-hover:text-vibrant-coral transition-colors leading-none">{user.name}</div>
+              <div className="text-[10px] font-mono uppercase opacity-60 mt-1.5">{user.role}</div>
+            </div>
+            <div className="w-10 h-10 bg-shadow-grey text-white font-display text-xl uppercase border-2 border-black shadow-brutal-sm group-hover:translate-x-1 group-hover:translate-y-1 group-hover:shadow-none transition-all flex items-center justify-center relative">
+              {user.name.charAt(0)}
+              <div className="absolute -top-1 -right-1 w-3 h-3 bg-vibrant-coral border-2 border-black rounded-sm" />
+            </div>
           </div>
         </div>
       ) : (

--- a/frontend/src/models/marketplace/Marketplace.ts
+++ b/frontend/src/models/marketplace/Marketplace.ts
@@ -191,6 +191,10 @@ export class Transaction {
   categoryId: string;
   finalPrice: number;
   completedAt: string | null;
+  // Optional denormalized fields populated by enriched queries
+  listingTitle?: string;
+  freelancerName?: string;
+  customerName?: string;
 
   constructor(data: {
     id: string;
@@ -201,27 +205,57 @@ export class Transaction {
     categoryId: string;
     finalPrice: number;
     completedAt: string | null;
+    listingTitle?: string;
+    freelancerName?: string;
+    customerName?: string;
   }) {
-    this.id           = data.id;
-    this.offerId      = data.offerId;
-    this.customerId   = data.customerId;
-    this.freelancerId = data.freelancerId;
-    this.listingId    = data.listingId;
-    this.categoryId   = data.categoryId;
-    this.finalPrice   = data.finalPrice;
-    this.completedAt  = data.completedAt;
+    this.id             = data.id;
+    this.offerId        = data.offerId;
+    this.customerId     = data.customerId;
+    this.freelancerId   = data.freelancerId;
+    this.listingId      = data.listingId;
+    this.categoryId     = data.categoryId;
+    this.finalPrice     = data.finalPrice;
+    this.completedAt    = data.completedAt;
+    this.listingTitle   = data.listingTitle;
+    this.freelancerName = data.freelancerName;
+    this.customerName   = data.customerName;
+  }
+
+  /**
+   * Marks the transaction as complete via the `complete-transaction` Edge Function.
+   * Only the customer may call this; the function enforces that server-side.
+   * Updates local state on success so callers don't need to refetch.
+   */
+  async markComplete(): Promise<void> {
+    const { data, error } = await supabase.functions.invoke('complete-transaction', {
+      body: { transaction_id: this.id },
+    });
+    if (error) throw error;
+    if (data?.transaction?.completed_at) {
+      this.completedAt = data.transaction.completed_at;
+    } else {
+      this.completedAt = new Date().toISOString();
+    }
+  }
+
+  get isComplete(): boolean {
+    return this.completedAt !== null;
   }
 
   static fromRow(row: Record<string, unknown>): Transaction {
     return new Transaction({
-      id:           row.id as string,
-      offerId:      row.offer_id as string,
-      customerId:   row.customer_id as string,
-      freelancerId: row.freelancer_id as string,
-      listingId:    row.listing_id as string,
-      categoryId:   row.category_id as string,
-      finalPrice:   row.final_price as number,
-      completedAt:  (row.completed_at as string) ?? null,
+      id:             row.id as string,
+      offerId:        row.offer_id as string,
+      customerId:     row.customer_id as string,
+      freelancerId:   row.freelancer_id as string,
+      listingId:      row.listing_id as string,
+      categoryId:     row.category_id as string,
+      finalPrice:     row.final_price as number,
+      completedAt:    (row.completed_at as string) ?? null,
+      listingTitle:   (row.listing_title as string) ?? undefined,
+      freelancerName: (row.freelancer_name as string) ?? undefined,
+      customerName:   (row.customer_name as string) ?? undefined,
     });
   }
 }

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -1,0 +1,312 @@
+import { useState, useEffect, useCallback } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import {
+  CheckCircle2,
+  Clock,
+  DollarSign,
+  Star,
+  AlertCircle,
+  ReceiptText,
+  ArrowLeft,
+} from 'lucide-react';
+import { Transaction } from '../models/marketplace/Marketplace';
+import { TransactionRepository } from '../services/repositories/Repositories';
+import { cn } from '../lib/utils';
+
+interface TransactionsPageProps {
+  user: { id: string; name: string; role: string };
+  onBack: () => void;
+}
+
+type TabFilter = 'all' | 'in-progress' | 'completed';
+
+// ── Status badge ──────────────────────────────────────────────
+const StatusBadge = ({ complete }: { complete: boolean }) => (
+  <span
+    className={cn(
+      'inline-flex items-center gap-1.5 px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest border-2 border-black',
+      complete
+        ? 'bg-shadow-grey text-white'
+        : 'bg-vibrant-coral text-white',
+    )}
+  >
+    {complete ? <CheckCircle2 size={10} /> : <Clock size={10} />}
+    {complete ? 'Completed' : 'In Progress'}
+  </span>
+);
+
+// ── Transaction Card ──────────────────────────────────────────
+const TransactionCard = ({
+  tx,
+  userId,
+  onMarkComplete,
+}: {
+  tx: Transaction;
+  userId: string;
+  onMarkComplete: (tx: Transaction) => Promise<void>;
+}) => {
+  const [marking, setMarking] = useState(false);
+  const [error, setError] = useState('');
+  const isCustomer = tx.customerId === userId;
+  const canComplete = isCustomer && !tx.isComplete;
+
+  const handleComplete = async () => {
+    setMarking(true);
+    setError('');
+    try {
+      await onMarkComplete(tx);
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to mark complete. Please try again.');
+    } finally {
+      setMarking(false);
+    }
+  };
+
+  const date = tx.completedAt
+    ? new Date(tx.completedAt).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      })
+    : new Date().toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -8 }}
+      className={cn(
+        'border-4 border-black bg-white shadow-brutal-sm p-6',
+        tx.isComplete && 'opacity-80',
+      )}
+    >
+      <div className="flex flex-col md:flex-row md:items-start justify-between gap-4">
+        {/* Left: listing + meta */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-3 flex-wrap mb-1">
+            <StatusBadge complete={tx.isComplete} />
+            <span className="font-mono text-[10px] uppercase opacity-40">{date}</span>
+          </div>
+
+          <h3 className="font-display uppercase text-xl tracking-tighter leading-tight mt-2 truncate">
+            {tx.listingTitle ?? 'Service'}
+          </h3>
+
+          <div className="grid grid-cols-2 gap-x-6 gap-y-1 mt-3">
+            <div className="font-mono text-[10px] uppercase opacity-50">Freelancer</div>
+            <div className="font-mono text-[10px] uppercase opacity-50">Customer</div>
+            <div className="font-mono text-sm truncate">{tx.freelancerName ?? tx.freelancerId.slice(0, 8) + '…'}</div>
+            <div className="font-mono text-sm truncate">{tx.customerName ?? tx.customerId.slice(0, 8) + '…'}</div>
+          </div>
+        </div>
+
+        {/* Right: price + actions */}
+        <div className="flex flex-col items-end gap-3 shrink-0">
+          <div className="flex items-center gap-2">
+            <DollarSign size={16} className="opacity-40" />
+            <span className="font-display text-3xl tracking-tighter text-vibrant-coral">
+              {Number(tx.finalPrice).toLocaleString('en-US', { minimumFractionDigits: 2 })}
+            </span>
+          </div>
+
+          {canComplete && (
+            <button
+              id={`mark-complete-${tx.id}`}
+              onClick={handleComplete}
+              disabled={marking}
+              className="flex items-center gap-2 px-4 py-2 bg-vibrant-coral text-white border-2 border-black font-display uppercase text-sm shadow-brutal-sm hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-none transition-all disabled:opacity-50 disabled:pointer-events-none"
+            >
+              <CheckCircle2 size={14} />
+              {marking ? 'Marking…' : 'Mark Complete'}
+            </button>
+          )}
+
+          {tx.isComplete && isCustomer && (
+            <div className="flex items-center gap-1.5 font-mono text-[10px] uppercase opacity-50">
+              <Star size={10} />
+              Review eligible
+            </div>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="mt-3 flex items-center gap-2 text-rosy-copper font-mono text-xs border-2 border-rosy-copper px-3 py-2">
+          <AlertCircle size={12} />
+          {error}
+        </div>
+      )}
+    </motion.div>
+  );
+};
+
+// ── Main page ─────────────────────────────────────────────────
+const repo = new TransactionRepository();
+
+export const TransactionsPage = ({ user, onBack }: TransactionsPageProps) => {
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState('');
+  const [filter, setFilter] = useState<TabFilter>('all');
+
+  const fetchTransactions = useCallback(async () => {
+    if (!user.id) return;
+    setLoading(true);
+    setFetchError('');
+    try {
+      const data = await repo.getByUserEnriched(user.id);
+      setTransactions(data);
+    } catch (e: any) {
+      setFetchError(e?.message ?? 'Failed to load transactions.');
+    } finally {
+      setLoading(false);
+    }
+  }, [user.id]);
+
+  useEffect(() => { fetchTransactions(); }, [fetchTransactions]);
+
+  const handleMarkComplete = async (tx: Transaction) => {
+    await tx.markComplete();
+    // Optimistically update local state — no need to refetch.
+    setTransactions(prev =>
+      prev.map(t => t.id === tx.id ? tx : t)
+    );
+  };
+
+  const filtered = transactions.filter(tx => {
+    if (filter === 'in-progress') return !tx.isComplete;
+    if (filter === 'completed')   return tx.isComplete;
+    return true;
+  });
+
+  const completedCount   = transactions.filter(t => t.isComplete).length;
+  const inProgressCount  = transactions.filter(t => !t.isComplete).length;
+  const totalValue       = transactions.reduce((acc, t) => acc + Number(t.finalPrice), 0);
+
+  const TABS: { key: TabFilter; label: string; count: number }[] = [
+    { key: 'all',         label: 'All',         count: transactions.length },
+    { key: 'in-progress', label: 'In Progress',  count: inProgressCount },
+    { key: 'completed',   label: 'Completed',    count: completedCount },
+  ];
+
+  return (
+    <main className="flex-1 bg-bone">
+      {/* ── Header ── */}
+      <div className="border-b-4 border-black bg-shadow-grey text-white px-8 py-10">
+        <div className="max-w-5xl mx-auto">
+          <button
+            onClick={onBack}
+            className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-widest opacity-60 hover:opacity-100 transition-opacity mb-4"
+          >
+            <ArrowLeft size={12} /> Back to Profile
+          </button>
+          <div className="font-mono text-[10px] uppercase tracking-widest opacity-60 mb-2">
+            Transactions
+          </div>
+          <h1 className="font-display uppercase text-4xl md:text-5xl tracking-tighter">
+            Transaction History
+          </h1>
+        </div>
+      </div>
+
+      <div className="max-w-5xl mx-auto px-8 py-10 space-y-8">
+        {/* ── Summary stats ── */}
+        <div className="grid grid-cols-3 gap-4">
+          {[
+            { label: 'Total Transactions', value: transactions.length },
+            { label: 'In Progress',        value: inProgressCount, accent: inProgressCount > 0 },
+            { label: 'Total Value',        value: `$${totalValue.toLocaleString('en-US', { minimumFractionDigits: 2 })}` },
+          ].map(({ label, value, accent }) => (
+            <div
+              key={label}
+              className={cn(
+                'border-4 border-black p-5 flex flex-col gap-1',
+                accent ? 'bg-vibrant-coral text-white' : 'bg-white',
+              )}
+            >
+              <div className="font-mono text-[10px] uppercase tracking-widest opacity-60">{label}</div>
+              <div className="font-display text-3xl tracking-tighter">{value}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* ── Tab bar ── */}
+        <div className="flex gap-0 border-4 border-black w-fit">
+          {TABS.map(({ key, label, count }) => (
+            <button
+              key={key}
+              id={`tab-${key}`}
+              onClick={() => setFilter(key)}
+              className={cn(
+                'px-5 py-2 font-display uppercase text-sm tracking-tight transition-colors',
+                filter === key
+                  ? 'bg-shadow-grey text-white'
+                  : 'bg-white hover:bg-black/5',
+              )}
+            >
+              {label} ({count})
+            </button>
+          ))}
+        </div>
+
+        {/* ── Content ── */}
+        {loading ? (
+          <div className="space-y-4">
+            {[1, 2, 3].map(i => (
+              <div
+                key={i}
+                className="border-4 border-black bg-white p-6 h-32 animate-pulse opacity-30"
+              />
+            ))}
+          </div>
+        ) : fetchError ? (
+          <div className="border-4 border-rosy-copper bg-white p-8 flex items-center gap-4">
+            <AlertCircle size={24} className="text-rosy-copper shrink-0" />
+            <div>
+              <div className="font-display uppercase text-lg tracking-tighter">
+                Failed to load transactions
+              </div>
+              <div className="font-mono text-sm opacity-60 mt-1">{fetchError}</div>
+              <button
+                onClick={fetchTransactions}
+                className="mt-3 font-mono text-xs uppercase underline hover:no-underline"
+              >
+                Try again
+              </button>
+            </div>
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="border-4 border-dashed border-black/20 p-14 text-center">
+            <ReceiptText size={36} className="mx-auto opacity-20 mb-4" />
+            <div className="font-display uppercase text-2xl opacity-30 mb-1">
+              {filter === 'all' ? 'No transactions yet' : `No ${filter} transactions`}
+            </div>
+            <div className="font-mono text-xs uppercase opacity-30">
+              {filter === 'all'
+                ? 'Accepted offers will appear here.'
+                : 'Switch to "All" to see everything.'}
+            </div>
+          </div>
+        ) : (
+          <AnimatePresence mode="popLayout">
+            <motion.div layout className="space-y-4">
+              {filtered.map(tx => (
+                <TransactionCard
+                  key={tx.id}
+                  tx={tx}
+                  userId={user.id}
+                  onMarkComplete={handleMarkComplete}
+                />
+              ))}
+            </motion.div>
+          </AnimatePresence>
+        )}
+      </div>
+    </main>
+  );
+};

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -3,12 +3,14 @@ interface UserProfileProps {
   onLogout: () => void;
   onGoToDashboard: () => void;
   onRoleChange: (role: string, updates?: Record<string, unknown>) => void;
+  onViewTransactions: () => void;
 }
 
 import { useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
+import { ReceiptText } from 'lucide-react';
 
-export const UserProfile = ({ user, onLogout, onGoToDashboard, onRoleChange }: UserProfileProps) => {
+export const UserProfile = ({ user, onLogout, onGoToDashboard, onRoleChange, onViewTransactions }: UserProfileProps) => {
   const [isEnrolling, setIsEnrolling] = useState(false);
   const [enrollLoading, setEnrollLoading] = useState(false);
   const [error, setError] = useState('');
@@ -142,6 +144,24 @@ export const UserProfile = ({ user, onLogout, onGoToDashboard, onRoleChange }: U
                 No active projects
               </div>
             )}
+          </div>
+        </div>
+
+        {/* Transaction history shortcut */}
+        <div className="mt-8 border-4 border-black p-6 bg-white">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="font-display uppercase text-sm tracking-widest mb-1">Transaction History</h2>
+              <p className="font-mono text-xs uppercase opacity-50">View & manage your accepted offers</p>
+            </div>
+            <button
+              id="view-transactions-btn"
+              onClick={onViewTransactions}
+              className="flex items-center gap-2 px-5 py-3 bg-shadow-grey text-white font-display uppercase text-sm border-2 border-black shadow-brutal-sm hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-none transition-all"
+            >
+              <ReceiptText size={14} />
+              View Transactions
+            </button>
           </div>
         </div>
 

--- a/frontend/src/services/repositories/Repositories.ts
+++ b/frontend/src/services/repositories/Repositories.ts
@@ -202,6 +202,31 @@ export class TransactionRepository {
     return (data ?? []).map(Transaction.fromRow);
   }
 
+  /**
+   * Like getByUser but joins listings (title) and both user records
+   * (display names) so the history page can render without additional
+   * round-trips.
+   */
+  async getByUserEnriched(userId: string): Promise<Transaction[]> {
+    const { data, error } = await supabase
+      .from('transactions')
+      .select(`
+        *,
+        listing:listings(title),
+        freelancer:users!transactions_freelancer_id_fkey(id, business_name, role),
+        customer:users!transactions_customer_id_fkey(id, business_name, role)
+      `)
+      .or(`customer_id.eq.${userId},freelancer_id.eq.${userId}`)
+      .order('completed_at', { ascending: false, nullsFirst: true });
+    if (error) throw error;
+    return (data ?? []).map((row: any) => Transaction.fromRow({
+      ...row,
+      listing_title:   row.listing?.title ?? null,
+      freelancer_name: row.freelancer?.business_name ?? null,
+      customer_name:   row.customer?.business_name ?? null,
+    }));
+  }
+
   async getByCategory(categoryId: string): Promise<Transaction[]> {
     const { data, error } = await supabase
       .from('transactions')

--- a/supabase/functions/complete-transaction/index.ts
+++ b/supabase/functions/complete-transaction/index.ts
@@ -1,0 +1,90 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+import { createUserClient, createServiceClient, corsHeaders } from "../_shared/supabase.ts";
+
+Deno.serve(async (req: Request) => {
+  // Handle CORS preflight
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405, headers: corsHeaders });
+  }
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  // Verify the caller's identity via their JWT.
+  const userClient = createUserClient(req);
+  const { data: { user }, error: authError } = await userClient.auth.getUser(
+    authHeader.replace("Bearer ", ""),
+  );
+  if (authError || !user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const { transaction_id } = await req.json() as { transaction_id: string };
+  if (!transaction_id) {
+    return new Response(JSON.stringify({ error: "transaction_id is required" }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  // Fetch the transaction and verify the caller is the customer.
+  const { data: tx, error: txError } = await userClient
+    .from("transactions")
+    .select("*")
+    .eq("id", transaction_id)
+    .single();
+
+  if (txError || !tx) {
+    return new Response(JSON.stringify({ error: "Transaction not found" }), {
+      status: 404,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  if (tx.customer_id !== user.id) {
+    return new Response(JSON.stringify({ error: "Only the customer may mark a transaction complete" }), {
+      status: 403,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  if (tx.completed_at !== null) {
+    return new Response(JSON.stringify({ error: "Transaction is already completed" }), {
+      status: 409,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  // Use the service-role client to set completed_at (bypasses RLS).
+  const serviceClient = createServiceClient();
+  const { data: updated, error: updateError } = await serviceClient
+    .from("transactions")
+    .update({ completed_at: new Date().toISOString() })
+    .eq("id", transaction_id)
+    .select()
+    .single();
+
+  if (updateError) {
+    return new Response(JSON.stringify({ error: updateError.message }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  return new Response(
+    JSON.stringify({ success: true, transaction: updated }),
+    { headers: { ...corsHeaders, "Content-Type": "application/json" } },
+  );
+});

--- a/supabase/migrations/20260512000014_transaction_complete_policy.sql
+++ b/supabase/migrations/20260512000014_transaction_complete_policy.sql
@@ -1,0 +1,23 @@
+-- ============================================================
+-- Migration 014: allow customers to mark their transactions complete
+-- The original transactions table only allows service_role inserts
+-- and participant selects.  We need to let the customer set
+-- completed_at so the "Mark Complete" button can work directly
+-- from the browser (the Edge Function uses service_role so this
+-- is belt-and-suspenders, but keeping it for direct-client path).
+-- ============================================================
+
+-- Customers may update completed_at on their own transactions,
+-- but only when the transaction is not already completed.
+CREATE POLICY "transactions_update_customer_complete"
+  ON transactions FOR UPDATE
+  TO authenticated
+  USING  (auth.uid() = customer_id AND completed_at IS NULL)
+  WITH CHECK (auth.uid() = customer_id);
+
+-- Freelancers may also mark their side complete (future-proof).
+CREATE POLICY "transactions_update_freelancer_complete"
+  ON transactions FOR UPDATE
+  TO authenticated
+  USING  (auth.uid() = freelancer_id AND completed_at IS NULL)
+  WITH CHECK (auth.uid() = freelancer_id);


### PR DESCRIPTION
- Add /transactions route and TransactionsPage with:
  - Stat cards: total count, in-progress, total value
  - Tab filter: All / In Progress / Completed
  - TransactionCard: lists listing title, freelancer & customer names, price, status badge, and 'Mark Complete' button (customer-only)
  - Review eligibility hint shown after completion
  - Animated skeleton loading state + retry-on-error UX
  - Optimistic local state update on mark-complete

- Add complete-transaction Edge Function:
  - Verifies caller is the customer via JWT
  - Guards against double-completion (409 Conflict)
  - Sets completed_at via service-role client

- Extend Transaction model:
  - markComplete() method invoking the edge function
  - isComplete computed getter
  - Optional display fields: listingTitle, freelancerName, customerName

- Add TransactionRepository.getByUserEnriched():
  - Joins listings (title) + both user rows for display names

- Add RLS migration 014: UPDATE policy for customer & freelancer to set completed_at on their own in-progress transactions

- Navbar: add 'Transactions' link for authenticated users
- UserProfile: add 'View Transactions' button navigating to /transactions