### PR TITLE
Add unit testing for frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,16 +25,79 @@
         "vite": "^6.2.0"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/express": "^4.17.21",
         "@types/node": "^22.14.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "autoprefixer": "^10.4.21",
+        "jsdom": "^29.1.1",
         "tailwindcss": "^4.1.14",
         "tsx": "^4.21.0",
         "typescript": "~5.8.2",
-        "vite": "^6.2.0"
+        "vite": "^6.2.0",
+        "vitest": "^4.1.6"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -254,6 +317,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -297,6 +370,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -713,6 +939,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@google/genai": {
@@ -1578,6 +1822,104 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1628,6 +1970,17 @@
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/connect": {
@@ -1701,6 +2054,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -1866,6 +2226,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1888,11 +2361,56 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
@@ -1961,6 +2479,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bignumber.js": {
@@ -2108,6 +2636,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2157,6 +2695,27 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/csstype": {
@@ -2296,6 +2855,20 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2313,6 +2886,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -2326,6 +2906,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -2346,6 +2936,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "17.4.1",
@@ -2416,6 +3014,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -2433,6 +3044,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -2513,6 +3131,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -2527,6 +3155,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/express": {
       "version": "4.22.1",
@@ -2917,6 +3555,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -2981,6 +3632,16 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3005,6 +3666,13 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -3019,6 +3687,57 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -3347,6 +4066,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3364,6 +4094,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -3423,6 +4160,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/motion": {
@@ -3555,6 +4302,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -3580,6 +4338,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3593,6 +4364,13 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -3648,6 +4426,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/protobufjs": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
@@ -3683,6 +4485,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -3846,6 +4658,20 @@
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -3859,6 +4685,16 @@
       "license": "MIT",
       "peerDependencies": {
         "redux": "^5.0.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/reselect": {
@@ -3955,6 +4791,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -4103,6 +4952,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4112,6 +4968,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -4120,6 +4983,33 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
@@ -4156,6 +5046,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4172,6 +5079,36 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -4179,6 +5116,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -4232,6 +5195,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -4859,6 +5832,109 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -4866,6 +5942,58 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ws": {
@@ -4888,6 +6016,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "preview": "vite preview",
     "clean": "rm -rf dist",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@google/genai": "^1.29.0",
@@ -28,14 +30,19 @@
     "vite": "^6.2.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/express": "^4.17.21",
     "@types/node": "^22.14.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "autoprefixer": "^10.4.21",
+    "jsdom": "^29.1.1",
     "tailwindcss": "^4.1.14",
     "tsx": "^4.21.0",
     "typescript": "~5.8.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^4.1.6"
   }
 }

--- a/frontend/src/components/ConfirmDeleteModal.test.tsx
+++ b/frontend/src/components/ConfirmDeleteModal.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ConfirmDeleteModal } from './ConfirmDeleteModal';
+
+describe('ConfirmDeleteModal', () => {
+  const defaultProps = {
+    title: 'Delete Listing',
+    message: 'Are you sure you want to delete this?',
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  it('renders title and message', () => {
+    render(<ConfirmDeleteModal {...defaultProps} />);
+    expect(screen.getByText('Delete Listing')).toBeInTheDocument();
+    expect(screen.getByText('Are you sure you want to delete this?')).toBeInTheDocument();
+  });
+
+  it('calls onConfirm when Delete is clicked', async () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmDeleteModal {...defaultProps} onConfirm={onConfirm} />);
+
+    await userEvent.click(screen.getByText('Delete'));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCancel when Cancel is clicked', async () => {
+    const onCancel = vi.fn();
+    render(<ConfirmDeleteModal {...defaultProps} onCancel={onCancel} />);
+
+    await userEvent.click(screen.getByText('Cancel'));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('shows "Deleting..." when loading', () => {
+    render(<ConfirmDeleteModal {...defaultProps} loading={true} />);
+    expect(screen.getByText('Deleting...')).toBeInTheDocument();
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+  });
+
+  it('disables buttons when loading', () => {
+    render(<ConfirmDeleteModal {...defaultProps} loading={true} />);
+    expect(screen.getByText('Cancel')).toBeDisabled();
+    expect(screen.getByText('Deleting...')).toBeDisabled();
+  });
+});

--- a/frontend/src/components/ListingCard.test.tsx
+++ b/frontend/src/components/ListingCard.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ListingCard } from './ListingCard';
+import type { Listing } from '../types/index';
+
+const listing: Listing = {
+  id: 'lst-1',
+  name: 'Alex Rivera',
+  role: 'UI/UX Designer',
+  category: 'design',
+  price: 45,
+  rating: 4.9,
+  reviews: 124,
+  location: 'Berlin, DE',
+  tags: ['Figma', 'Prototyping'],
+  color: 'bg-vibrant-coral',
+  completedJobs: 98,
+};
+
+function renderCard() {
+  return render(
+    <MemoryRouter>
+      <ListingCard listing={listing} />
+    </MemoryRouter>
+  );
+}
+
+describe('ListingCard', () => {
+  it('renders the freelancer name and role', () => {
+    renderCard();
+    expect(screen.getByText('Alex Rivera')).toBeInTheDocument();
+    expect(screen.getByText('UI/UX Designer')).toBeInTheDocument();
+  });
+
+  it('displays the price', () => {
+    renderCard();
+    expect(screen.getByText('$45')).toBeInTheDocument();
+  });
+
+  it('displays tags', () => {
+    renderCard();
+    expect(screen.getByText('Figma')).toBeInTheDocument();
+    expect(screen.getByText('Prototyping')).toBeInTheDocument();
+  });
+
+  it('shows the rating', () => {
+    renderCard();
+    expect(screen.getByText('4.9')).toBeInTheDocument();
+  });
+
+  it('shows the location', () => {
+    renderCard();
+    expect(screen.getByText('Berlin, DE')).toBeInTheDocument();
+  });
+
+  it('links to the freelancer profile page', () => {
+    renderCard();
+    const link = screen.getByRole('link', { name: /view profile/i });
+    expect(link).toHaveAttribute('href', '/freelancer/lst-1');
+  });
+
+  it('renders the initial letter avatar', () => {
+    renderCard();
+    expect(screen.getByText('A')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Spinner.test.tsx
+++ b/frontend/src/components/Spinner.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { Spinner } from './Spinner';
+
+describe('Spinner', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<Spinner />);
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it('contains an SVG element (the Loader2 icon)', () => {
+    const { container } = render(<Spinner />);
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+});

--- a/frontend/src/data/mockData.test.ts
+++ b/frontend/src/data/mockData.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { getPricingReport, LISTINGS } from './mockData';
+import type { ScatterPoint } from '../types/index';
+
+describe('getPricingReport', () => {
+  it('returns a report for a design-category listing', () => {
+    const listing = LISTINGS[0]; // Alex Rivera, design, $45
+    const report = getPricingReport(listing);
+    expect(report.category).toBe(listing.role);
+    expect(report.marketAvg).toBe(58);
+    expect(report.marketMedian).toBe(55);
+    expect(report.sampleSize).toBe(144);
+    expect(report.priceDistribution.length).toBeGreaterThan(0);
+    expect(report.scatterData.length).toBeGreaterThan(0);
+    expect(report.percentile).toBeGreaterThanOrEqual(0);
+    expect(report.percentile).toBeLessThanOrEqual(100);
+  });
+
+  it('returns a report for a development-category listing', () => {
+    const listing = LISTINGS[1]; // Sarah Chen, development, $85
+    const report = getPricingReport(listing);
+    expect(report.marketAvg).toBe(92);
+    expect(report.sampleSize).toBe(146);
+  });
+
+  it('marks the current freelancer in scatter data when name matches', () => {
+    // Marco Rossi appears by name in DESIGN_SCATTER
+    const listing = LISTINGS[2];
+    const report = getPricingReport(listing);
+    const current = report.scatterData.find((p: ScatterPoint) => p.isCurrent);
+    expect(current).toBeDefined();
+    expect(current!.name).toBe('Marco Rossi');
+  });
+
+  it('does not mark anyone when no name matches in scatter data', () => {
+    const listing = LISTINGS[0]; // Alex Rivera — not in scatter data by name
+    const report = getPricingReport(listing);
+    const current = report.scatterData.find((p: ScatterPoint) => p.isCurrent);
+    expect(current).toBeUndefined();
+  });
+
+  it('falls back to design data for unknown categories', () => {
+    const fakeListing = { ...LISTINGS[0], category: 'nonexistent' };
+    const report = getPricingReport(fakeListing);
+    expect(report.marketAvg).toBe(58);
+  });
+});

--- a/frontend/src/hooks/useAuth.test.ts
+++ b/frontend/src/hooks/useAuth.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useAuth } from './useAuth';
+import { supabase } from '../lib/supabaseClient';
+import { FreelancerUser, CustomerUser } from '../models/users/UserSubclasses';
+import { BaseUser } from '../models/users/BaseUser';
+
+const mockAuth = supabase.auth as any;
+const mockFrom = supabase.from as any;
+
+const freelancerRow = {
+  id: 'user-1',
+  email: 'free@test.com',
+  role: 'freelancer',
+  created_at: '2024-01-01T00:00:00Z',
+  is_banned: false,
+  banned_at: null,
+  ban_reason: null,
+  business_name: 'Studio',
+  summary: null,
+  service_area: null,
+  zip_code: null,
+  avatar_url: null,
+};
+
+const customerRow = {
+  ...freelancerRow,
+  id: 'user-2',
+  email: 'cust@test.com',
+  role: 'customer',
+};
+
+function mockSessionAndRow(session: any, row: any) {
+  mockAuth.getSession.mockResolvedValue({ data: { session } });
+  mockAuth.onAuthStateChange.mockReturnValue({
+    data: { subscription: { unsubscribe: vi.fn() } },
+  });
+
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: row, error: null }),
+  };
+  mockFrom.mockReturnValue(chain);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useAuth', () => {
+  it('returns null user when no session exists', async () => {
+    mockSessionAndRow(null, null);
+
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.user).toBeNull();
+    expect(result.current.session).toBeNull();
+  });
+
+  it('hydrates a FreelancerUser from session', async () => {
+    const session = { user: { id: 'user-1' } };
+    mockSessionAndRow(session, freelancerRow);
+
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.user).toBeInstanceOf(FreelancerUser);
+    expect(result.current.session).toEqual(session);
+  });
+
+  it('hydrates a CustomerUser from session', async () => {
+    const session = { user: { id: 'user-2' } };
+    mockSessionAndRow(session, customerRow);
+
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.user).toBeInstanceOf(CustomerUser);
+  });
+
+  it('returns null user when DB lookup fails', async () => {
+    const session = { user: { id: 'user-1' } };
+    mockAuth.getSession.mockResolvedValue({ data: { session } });
+    mockAuth.onAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    });
+
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: { message: 'not found' } }),
+    };
+    mockFrom.mockReturnValue(chain);
+
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.user).toBeNull();
+  });
+
+  it('returns BaseUser for admin role', async () => {
+    const session = { user: { id: 'admin-1' } };
+    mockSessionAndRow(session, { ...freelancerRow, id: 'admin-1', role: 'admin' });
+
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.user).toBeInstanceOf(BaseUser);
+  });
+});

--- a/frontend/src/hooks/useInactivityLogout.test.ts
+++ b/frontend/src/hooks/useInactivityLogout.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useInactivityLogout } from './useInactivityLogout';
+import { supabase } from '../lib/supabaseClient';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useInactivityLogout', () => {
+  it('calls signOut after 15 minutes of inactivity', () => {
+    renderHook(() => useInactivityLogout());
+
+    vi.advanceTimersByTime(15 * 60 * 1000);
+
+    expect(supabase.auth.signOut).toHaveBeenCalledOnce();
+  });
+
+  it('does not call signOut before 15 minutes', () => {
+    renderHook(() => useInactivityLogout());
+
+    vi.advanceTimersByTime(14 * 60 * 1000);
+
+    expect(supabase.auth.signOut).not.toHaveBeenCalled();
+  });
+
+  it('resets the timer on user activity (respecting throttle)', () => {
+    renderHook(() => useInactivityLogout());
+
+    // Advance past the 30s throttle window, then trigger activity
+    vi.advanceTimersByTime(31_000);
+    window.dispatchEvent(new Event('mousemove'));
+
+    // Now 15 minutes from that reset should trigger logout
+    vi.advanceTimersByTime(15 * 60 * 1000);
+    expect(supabase.auth.signOut).toHaveBeenCalledOnce();
+  });
+
+  it('throttles rapid activity events', () => {
+    renderHook(() => useInactivityLogout());
+
+    // Fire many events within the 30s throttle window
+    for (let i = 0; i < 10; i++) {
+      window.dispatchEvent(new Event('keydown'));
+    }
+
+    // The timer should NOT have been reset (still within throttle),
+    // so logout fires at the original 15-minute mark
+    vi.advanceTimersByTime(15 * 60 * 1000);
+    expect(supabase.auth.signOut).toHaveBeenCalledOnce();
+  });
+
+  it('cleans up listeners and timer on unmount', () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => useInactivityLogout());
+
+    unmount();
+
+    const removedEvents = removeSpy.mock.calls.map(c => c[0]);
+    expect(removedEvents).toContain('mousemove');
+    expect(removedEvents).toContain('keydown');
+    expect(removedEvents).toContain('scroll');
+
+    // After unmount, advancing time should not trigger signOut
+    vi.clearAllMocks();
+    vi.advanceTimersByTime(15 * 60 * 1000);
+    expect(supabase.auth.signOut).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/models/marketplace/Marketplace.test.ts
+++ b/frontend/src/models/marketplace/Marketplace.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { Category, ServiceListing, Offer, Transaction } from './Marketplace';
+import { FixedPriceStrategy, HourlyStrategy } from '../pricing/PricingStrategy';
+
+describe('Category', () => {
+  it('hydrates from a database row', () => {
+    const cat = Category.fromRow({ id: 'cat-1', name: 'Design', slug: 'design' });
+    expect(cat).toBeInstanceOf(Category);
+    expect(cat.id).toBe('cat-1');
+    expect(cat.name).toBe('Design');
+    expect(cat.slug).toBe('design');
+  });
+});
+
+describe('ServiceListing', () => {
+  const baseRow = {
+    id: 'lst-1',
+    freelancer_id: 'user-1',
+    category_id: 'cat-1',
+    title: 'Logo Design',
+    description: 'Professional logo design',
+    is_active: true,
+    created_at: '2024-01-15T00:00:00Z',
+  };
+
+  it('hydrates from a database row without pricing', () => {
+    const listing = ServiceListing.fromRow(baseRow);
+    expect(listing).toBeInstanceOf(ServiceListing);
+    expect(listing.id).toBe('lst-1');
+    expect(listing.freelancerId).toBe('user-1');
+    expect(listing.title).toBe('Logo Design');
+    expect(listing.isActive).toBe(true);
+    expect(listing.pricingStrategy).toBeNull();
+  });
+
+  it('hydrates with a pricing row', () => {
+    const listing = ServiceListing.fromRow(baseRow, {
+      strategy_type: 'fixed',
+      base_price: 200,
+    });
+    expect(listing.pricingStrategy).toBeInstanceOf(FixedPriceStrategy);
+    expect(listing.getPrice()).toBe(200);
+  });
+
+  it('throws when getPrice is called without a strategy', () => {
+    const listing = ServiceListing.fromRow(baseRow);
+    expect(() => listing.getPrice()).toThrow('No pricing strategy loaded');
+  });
+
+  it('hydrates hourly pricing from row', () => {
+    const listing = ServiceListing.fromRow(baseRow, {
+      strategy_type: 'hourly',
+      base_price: 85,
+    });
+    expect(listing.pricingStrategy).toBeInstanceOf(HourlyStrategy);
+    expect(listing.getPrice()).toBe(85);
+  });
+});
+
+describe('Offer', () => {
+  const offerRow = {
+    id: 'off-1',
+    customer_id: 'cust-1',
+    freelancer_id: 'free-1',
+    listing_id: 'lst-1',
+    amount: 500,
+    scope: 'Build a landing page',
+    status: 'pending',
+    expires_at: '2024-06-01T00:00:00Z',
+    created_at: '2024-05-01T00:00:00Z',
+  };
+
+  it('hydrates from a database row', () => {
+    const offer = Offer.fromRow(offerRow);
+    expect(offer).toBeInstanceOf(Offer);
+    expect(offer.id).toBe('off-1');
+    expect(offer.customerId).toBe('cust-1');
+    expect(offer.freelancerId).toBe('free-1');
+    expect(offer.amount).toBe(500);
+    expect(offer.scope).toBe('Build a landing page');
+    expect(offer.status).toBe('pending');
+    expect(offer.expiresAt).toBe('2024-06-01T00:00:00Z');
+  });
+
+  it('handles null scope and expires_at', () => {
+    const offer = Offer.fromRow({ ...offerRow, scope: undefined, expires_at: undefined });
+    expect(offer.scope).toBeNull();
+    expect(offer.expiresAt).toBeNull();
+  });
+});
+
+describe('Transaction', () => {
+  const txRow = {
+    id: 'tx-1',
+    offer_id: 'off-1',
+    customer_id: 'cust-1',
+    freelancer_id: 'free-1',
+    listing_id: 'lst-1',
+    category_id: 'cat-1',
+    final_price: 500,
+    completed_at: null,
+  };
+
+  it('hydrates from a database row', () => {
+    const tx = Transaction.fromRow(txRow);
+    expect(tx).toBeInstanceOf(Transaction);
+    expect(tx.id).toBe('tx-1');
+    expect(tx.finalPrice).toBe(500);
+    expect(tx.isComplete).toBe(false);
+  });
+
+  it('isComplete is true when completed_at is set', () => {
+    const tx = Transaction.fromRow({ ...txRow, completed_at: '2024-06-01T00:00:00Z' });
+    expect(tx.isComplete).toBe(true);
+  });
+
+  it('includes optional denormalized fields', () => {
+    const tx = Transaction.fromRow({
+      ...txRow,
+      listing_title: 'Logo Design',
+      freelancer_name: 'Alex',
+      customer_name: 'Bob',
+    });
+    expect(tx.listingTitle).toBe('Logo Design');
+    expect(tx.freelancerName).toBe('Alex');
+    expect(tx.customerName).toBe('Bob');
+  });
+
+  it('optional fields are undefined when absent', () => {
+    const tx = Transaction.fromRow(txRow);
+    expect(tx.listingTitle).toBeUndefined();
+    expect(tx.freelancerName).toBeUndefined();
+    expect(tx.customerName).toBeUndefined();
+  });
+});

--- a/frontend/src/models/pricing/PricingStrategy.test.ts
+++ b/frontend/src/models/pricing/PricingStrategy.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+  FixedPriceStrategy,
+  HourlyStrategy,
+  ProjectStrategy,
+  strategyFromRow,
+} from './PricingStrategy';
+
+describe('FixedPriceStrategy', () => {
+  it('returns the fixed price', () => {
+    const strategy = new FixedPriceStrategy(250);
+    expect(strategy.type).toBe('fixed');
+    expect(strategy.calculatePrice()).toBe(250);
+  });
+
+  it('handles zero price', () => {
+    expect(new FixedPriceStrategy(0).calculatePrice()).toBe(0);
+  });
+});
+
+describe('HourlyStrategy', () => {
+  it('calculates hourly rate × estimated hours', () => {
+    const strategy = new HourlyStrategy(85, 10);
+    expect(strategy.type).toBe('hourly');
+    expect(strategy.calculatePrice()).toBe(850);
+  });
+
+  it('returns zero when hours are zero', () => {
+    expect(new HourlyStrategy(100, 0).calculatePrice()).toBe(0);
+  });
+});
+
+describe('ProjectStrategy', () => {
+  it('returns the flat project price when no milestones', () => {
+    const strategy = new ProjectStrategy(2400);
+    expect(strategy.type).toBe('project');
+    expect(strategy.calculatePrice()).toBe(2400);
+  });
+
+  it('sums milestone amounts when milestones exist', () => {
+    const strategy = new ProjectStrategy(2400, [
+      { title: 'Design', amount: 800 },
+      { title: 'Build', amount: 1200 },
+      { title: 'QA', amount: 400 },
+    ]);
+    expect(strategy.calculatePrice()).toBe(2400);
+  });
+
+  it('milestone sum can differ from projectPrice', () => {
+    const strategy = new ProjectStrategy(1000, [
+      { title: 'Phase 1', amount: 600 },
+      { title: 'Phase 2', amount: 900 },
+    ]);
+    expect(strategy.calculatePrice()).toBe(1500);
+  });
+});
+
+describe('strategyFromRow', () => {
+  it('creates FixedPriceStrategy for fixed type', () => {
+    const strategy = strategyFromRow({ strategy_type: 'fixed', base_price: 200 });
+    expect(strategy).toBeInstanceOf(FixedPriceStrategy);
+    expect(strategy.calculatePrice()).toBe(200);
+  });
+
+  it('creates HourlyStrategy with estimatedHours=1 for hourly type', () => {
+    const strategy = strategyFromRow({ strategy_type: 'hourly', base_price: 75 });
+    expect(strategy).toBeInstanceOf(HourlyStrategy);
+    expect(strategy.calculatePrice()).toBe(75);
+  });
+
+  it('creates ProjectStrategy for project type', () => {
+    const strategy = strategyFromRow({ strategy_type: 'project', base_price: 3000 });
+    expect(strategy).toBeInstanceOf(ProjectStrategy);
+    expect(strategy.calculatePrice()).toBe(3000);
+  });
+});

--- a/frontend/src/models/reviews/ReviewsAndMessaging.test.ts
+++ b/frontend/src/models/reviews/ReviewsAndMessaging.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { Review, ReviewResponse, Conversation, Message } from './ReviewsAndMessaging';
+
+describe('Review', () => {
+  const row = {
+    id: 'rev-1',
+    transaction_id: 'tx-1',
+    customer_id: 'cust-1',
+    freelancer_id: 'free-1',
+    ratings: { communication: 5, quality: 4, speed: 3 },
+    body: 'Great work overall!',
+    created_at: '2024-06-01T00:00:00Z',
+  };
+
+  it('hydrates from a database row', () => {
+    const review = Review.fromRow(row);
+    expect(review).toBeInstanceOf(Review);
+    expect(review.id).toBe('rev-1');
+    expect(review.transactionId).toBe('tx-1');
+    expect(review.ratings.communication).toBe(5);
+    expect(review.body).toBe('Great work overall!');
+  });
+
+  describe('validate', () => {
+    it('returns true for valid ratings (1–5) and non-empty body', () => {
+      const review = Review.fromRow(row);
+      expect(review.validate()).toBe(true);
+    });
+
+    it('returns false when a rating is below 1', () => {
+      const review = Review.fromRow({ ...row, ratings: { communication: 0, quality: 4, speed: 3 } });
+      expect(review.validate()).toBe(false);
+    });
+
+    it('returns false when a rating is above 5', () => {
+      const review = Review.fromRow({ ...row, ratings: { communication: 5, quality: 6, speed: 3 } });
+      expect(review.validate()).toBe(false);
+    });
+
+    it('returns false when body is empty', () => {
+      const review = Review.fromRow({ ...row, body: '   ' });
+      expect(review.validate()).toBe(false);
+    });
+
+    it('returns false when ratings object is empty', () => {
+      const review = Review.fromRow({ ...row, ratings: {} });
+      expect(review.validate()).toBe(false);
+    });
+  });
+});
+
+describe('ReviewResponse', () => {
+  it('hydrates from a database row', () => {
+    const resp = ReviewResponse.fromRow({
+      id: 'rr-1',
+      review_id: 'rev-1',
+      freelancer_id: 'free-1',
+      body: 'Thank you for the feedback!',
+      created_at: '2024-06-02T00:00:00Z',
+    });
+    expect(resp).toBeInstanceOf(ReviewResponse);
+    expect(resp.reviewId).toBe('rev-1');
+    expect(resp.body).toBe('Thank you for the feedback!');
+  });
+});
+
+describe('Conversation', () => {
+  it('hydrates from a database row', () => {
+    const conv = Conversation.fromRow({
+      id: 'conv-1',
+      customer_id: 'cust-1',
+      freelancer_id: 'free-1',
+      created_at: '2024-05-01T00:00:00Z',
+    });
+    expect(conv).toBeInstanceOf(Conversation);
+    expect(conv.customerId).toBe('cust-1');
+    expect(conv.freelancerId).toBe('free-1');
+  });
+});
+
+describe('Message', () => {
+  it('hydrates from a database row', () => {
+    const msg = Message.fromRow({
+      id: 'msg-1',
+      conversation_id: 'conv-1',
+      sender_id: 'cust-1',
+      body: 'Hello, I have a project for you.',
+      created_at: '2024-05-01T12:00:00Z',
+    });
+    expect(msg).toBeInstanceOf(Message);
+    expect(msg.conversationId).toBe('conv-1');
+    expect(msg.senderId).toBe('cust-1');
+    expect(msg.body).toBe('Hello, I have a project for you.');
+  });
+});

--- a/frontend/src/models/users/BaseUser.test.ts
+++ b/frontend/src/models/users/BaseUser.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { BaseUser } from './BaseUser';
+
+describe('BaseUser', () => {
+  const row = {
+    id: 'user-1',
+    email: 'test@example.com',
+    role: 'customer',
+    created_at: '2024-01-01T00:00:00Z',
+    is_banned: false,
+    banned_at: null,
+    ban_reason: null,
+  };
+
+  it('hydrates from a database row', () => {
+    const user = BaseUser.fromRow(row);
+    expect(user).toBeInstanceOf(BaseUser);
+    expect(user.id).toBe('user-1');
+    expect(user.email).toBe('test@example.com');
+    expect(user.role).toBe('customer');
+    expect(user.isBanned).toBe(false);
+    expect(user.bannedAt).toBeNull();
+    expect(user.banReason).toBeNull();
+  });
+
+  it('handles banned user fields', () => {
+    const banned = BaseUser.fromRow({
+      ...row,
+      is_banned: true,
+      banned_at: '2024-03-15T00:00:00Z',
+      ban_reason: 'spam',
+    });
+    expect(banned.isBanned).toBe(true);
+    expect(banned.bannedAt).toBe('2024-03-15T00:00:00Z');
+    expect(banned.banReason).toBe('spam');
+  });
+
+  it('can be constructed directly', () => {
+    const user = new BaseUser({
+      id: 'u-2',
+      email: 'admin@test.com',
+      role: 'admin',
+      createdAt: '2024-01-01T00:00:00Z',
+      isBanned: false,
+      bannedAt: null,
+      banReason: null,
+    });
+    expect(user.role).toBe('admin');
+  });
+});

--- a/frontend/src/models/users/UserSubclasses.test.ts
+++ b/frontend/src/models/users/UserSubclasses.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { FreelancerUser, CustomerUser, AdminUser } from './UserSubclasses';
+import { BaseUser } from './BaseUser';
+
+const baseRow = {
+  id: 'user-1',
+  email: 'test@example.com',
+  role: 'freelancer',
+  created_at: '2024-01-01T00:00:00Z',
+  is_banned: false,
+  banned_at: null,
+  ban_reason: null,
+};
+
+describe('FreelancerUser', () => {
+  const row = {
+    ...baseRow,
+    business_name: 'Alex Design Studio',
+    summary: 'UI/UX designer',
+    service_area: 'Berlin, DE',
+    zip_code: '10115',
+    avatar_url: 'https://example.com/avatar.jpg',
+  };
+
+  it('hydrates from a database row via fromRow', () => {
+    const data = FreelancerUser.fromRow(row);
+    const user = new FreelancerUser(data);
+    expect(user).toBeInstanceOf(FreelancerUser);
+    expect(user).toBeInstanceOf(BaseUser);
+    expect(user.businessName).toBe('Alex Design Studio');
+    expect(user.summary).toBe('UI/UX designer');
+    expect(user.serviceArea).toBe('Berlin, DE');
+    expect(user.zipCode).toBe('10115');
+    expect(user.avatarUrl).toBe('https://example.com/avatar.jpg');
+    expect(user.role).toBe('freelancer');
+  });
+
+  it('handles null optional fields', () => {
+    const data = FreelancerUser.fromRow(baseRow);
+    const user = new FreelancerUser(data);
+    expect(user.businessName).toBeNull();
+    expect(user.summary).toBeNull();
+    expect(user.serviceArea).toBeNull();
+    expect(user.zipCode).toBeNull();
+    expect(user.avatarUrl).toBeNull();
+  });
+});
+
+describe('CustomerUser', () => {
+  const row = { ...baseRow, role: 'customer', zip_code: '02101' };
+
+  it('hydrates from a database row', () => {
+    const data = CustomerUser.fromRow(row);
+    const user = new CustomerUser(data);
+    expect(user).toBeInstanceOf(CustomerUser);
+    expect(user).toBeInstanceOf(BaseUser);
+    expect(user.location).toBe('02101');
+    expect(user.searchHistory).toEqual([]);
+    expect(user.role).toBe('customer');
+  });
+
+  it('location is null when zip_code is missing', () => {
+    const data = CustomerUser.fromRow({ ...baseRow, role: 'customer' });
+    const user = new CustomerUser(data);
+    expect(user.location).toBeNull();
+  });
+});
+
+describe('AdminUser', () => {
+  it('extends BaseUser', () => {
+    const user = new AdminUser({
+      id: 'admin-1',
+      email: 'admin@vtdk.com',
+      role: 'admin',
+      createdAt: '2024-01-01T00:00:00Z',
+      isBanned: false,
+      bannedAt: null,
+      banReason: null,
+    });
+    expect(user).toBeInstanceOf(AdminUser);
+    expect(user).toBeInstanceOf(BaseUser);
+    expect(user.role).toBe('admin');
+  });
+});

--- a/frontend/src/services/repositories/CoreServices.test.ts
+++ b/frontend/src/services/repositories/CoreServices.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { ReportFactory } from './CoreServices';
+
+describe('ReportFactory.createReport', () => {
+  const aggregate = {
+    category_id: 'cat-1',
+    transaction_count: 50,
+    price_min: 20,
+    price_max: 200,
+    price_avg: 85,
+    price_median: 80,
+  };
+
+  const prediction = { minPrice: 60, maxPrice: 120, suggestedPrice: 90 };
+  const anomalies = { outlierIndices: [3], scores: [0.1, 0.2, 0.15, 0.95] };
+
+  it('creates a customer report', () => {
+    const report = ReportFactory.createReport('customer', { aggregate, prediction, anomalies });
+    expect(report.type).toBe('customer');
+    expect(report.categoryId).toBe('cat-1');
+    expect(report.marketMin).toBe(20);
+    expect(report.marketMax).toBe(200);
+    expect(report.marketAvg).toBe(85);
+    expect(report.marketMedian).toBe(80);
+    expect(report.transactionCount).toBe(50);
+    expect(report.prediction).toEqual(prediction);
+    expect(report.anomalies).toEqual(anomalies);
+    expect('ownPrices' in report).toBe(false);
+  });
+
+  it('creates a freelancer report with ownPrices', () => {
+    const ownPrices = [75, 80, 90];
+    const report = ReportFactory.createReport('freelancer', { aggregate, prediction, anomalies, ownPrices });
+    expect(report.type).toBe('freelancer');
+    if (report.type === 'freelancer') {
+      expect(report.ownPrices).toEqual([75, 80, 90]);
+    }
+  });
+
+  it('defaults ownPrices to empty array for freelancer', () => {
+    const report = ReportFactory.createReport('freelancer', { aggregate, prediction, anomalies });
+    if (report.type === 'freelancer') {
+      expect(report.ownPrices).toEqual([]);
+    }
+  });
+});

--- a/frontend/src/services/repositories/Repositories.test.ts
+++ b/frontend/src/services/repositories/Repositories.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { UserRepository } from './Repositories';
+import { FreelancerUser, CustomerUser } from '../../models/users/UserSubclasses';
+import { BaseUser } from '../../models/users/BaseUser';
+
+describe('UserRepository.hydrateUser', () => {
+  const baseRow = {
+    id: 'user-1',
+    email: 'test@example.com',
+    created_at: '2024-01-01T00:00:00Z',
+    is_banned: false,
+    banned_at: null,
+    ban_reason: null,
+  };
+
+  it('returns FreelancerUser for freelancer role', () => {
+    const user = UserRepository.hydrateUser({
+      ...baseRow,
+      role: 'freelancer',
+      business_name: 'Studio',
+      summary: null,
+      service_area: null,
+      zip_code: null,
+      avatar_url: null,
+    });
+    expect(user).toBeInstanceOf(FreelancerUser);
+    expect((user as FreelancerUser).businessName).toBe('Studio');
+  });
+
+  it('returns CustomerUser for customer role', () => {
+    const user = UserRepository.hydrateUser({
+      ...baseRow,
+      role: 'customer',
+      zip_code: '02101',
+    });
+    expect(user).toBeInstanceOf(CustomerUser);
+    expect((user as CustomerUser).location).toBe('02101');
+  });
+
+  it('returns BaseUser for unknown roles', () => {
+    const user = UserRepository.hydrateUser({
+      ...baseRow,
+      role: 'admin',
+    });
+    expect(user).toBeInstanceOf(BaseUser);
+  });
+});

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,40 @@
+import '@testing-library/jest-dom/vitest';
+import { vi } from 'vitest';
+
+vi.mock('../lib/supabaseClient', () => {
+  const mockAuth = {
+    getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+    getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+    onAuthStateChange: vi.fn().mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } }),
+    signInWithPassword: vi.fn(),
+    signUp: vi.fn(),
+    signOut: vi.fn().mockResolvedValue({ error: null }),
+    updateUser: vi.fn(),
+  };
+
+  const mockFrom = vi.fn().mockReturnValue({
+    select: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    upsert: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    or: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    then: vi.fn(),
+  });
+
+  return {
+    supabase: {
+      auth: mockAuth,
+      from: mockFrom,
+      functions: {
+        invoke: vi.fn().mockResolvedValue({ data: null, error: null }),
+      },
+      rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
+    },
+  };
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
+});


### PR DESCRIPTION
## Summary
- Add frontend unit testing infrastructure using Vitest + React Testing Library
- 73 tests across 13 test files covering models, services, hooks, and components
- No existing source files modified (only added test scripts to package.json)

## How to run

```bash
cd frontend
npm test
```

## What's tested
- Models: PricingStrategy (fixed/hourly/project), Marketplace (Listing, Offer, Transaction), Users (BaseUser, FreelancerUser, - CustomerUser, AdminUser), Reviews & Messaging
- Services: UserRepository.hydrateUser, ReportFactory, getPricingReport
- Hooks: useAuth (session hydration, role dispatch), useInactivityLogout (timer, throttle, cleanup)
- Components: Spinner, ConfirmDeleteModal, ListingCard
